### PR TITLE
allow global formatOnSave setting

### DIFF
--- a/Scripts/config.js
+++ b/Scripts/config.js
@@ -3,6 +3,24 @@ class Config {
         let global = nova.config.get(nova.extension.identifier + "." + key);
         let workspace = nova.workspace.config.get(nova.extension.identifier + "." + key);
 
+        // handle booleans as enums at the workspace level
+        // doesn't seem to be a way to look up if the config is an enum
+        if (key === "formatOnSave") {
+          // enums must have string values, so map strings to boolean + null
+          switch(workspace) {
+            case "null":
+              workspace = null;
+              break;
+            case "true":
+              workspace = true;
+              break;
+            case "false":
+              workspace = false;
+              break;
+            default:
+              console.error(`Unexpected ${key}: ${workspace}`)
+          }
+        }
         if (workspace !== null && global !== workspace) return workspace;
         return global;
     }

--- a/Scripts/config.js
+++ b/Scripts/config.js
@@ -3,24 +3,11 @@ class Config {
         let global = nova.config.get(nova.extension.identifier + "." + key);
         let workspace = nova.workspace.config.get(nova.extension.identifier + "." + key);
 
-        // handle booleans as enums at the workspace level
-        // doesn't seem to be a way to look up if the config is an enum
-        if (key === "formatOnSave") {
-          // enums must have string values, so map strings to boolean + null
-          switch(workspace) {
-            case "null":
-              workspace = null;
-              break;
-            case "true":
-              workspace = true;
-              break;
-            case "false":
-              workspace = false;
-              break;
-            default:
-              console.error(`Unexpected ${key}: ${workspace}`)
-          }
+        if (typeof global === "boolean" && typeof workspace == "number") {
+            if (workspace === -1) workspace = null
+            else workspace = Boolean(workspace)
         }
+
         if (workspace !== null && global !== workspace) return workspace;
         return global;
     }

--- a/extension.json
+++ b/extension.json
@@ -73,10 +73,10 @@
         },
         {
             "key": "cc.aeron.nova-isort.formatOnSave",
-            "title": "Format on a file save (overrides global setting)",
+            "title": "Format on a file save",
             "type": "enum",
-            "values": [["null", "use global setting"], ["true", "yes"], ["false", "no"]],
-            "default": "null"
+            "values": [[-1, "Global"], [1, "Yes"], [0, "No"]],
+            "default": -1
         }
     ]
 }

--- a/extension.json
+++ b/extension.json
@@ -73,9 +73,10 @@
         },
         {
             "key": "cc.aeron.nova-isort.formatOnSave",
-            "title": "Format on a file save",
-            "type": "boolean",
-            "default": true
+            "title": "Format on a file save (overrides global setting)",
+            "type": "enum",
+            "values": [["null", "use global setting"], ["true", "yes"], ["false", "no"]],
+            "default": "null"
         }
     ]
 }


### PR DESCRIPTION
In general, boolean workspace config values [cannot be null](https://devforum.nova.app/t/override-global-configuration-in-workspace/1824), so [this workspace !== null](https://github.com/Aeron/isort.novaextension/blob/7da0c43f9d940aa2c32a194d49b45a5d6da004f9/Scripts/config.js#L6) condition will always be true for formatOnSave, meaning the workspace config is the only value ever used, the global config can never have an affect.

There's no easy solution for 'boolean, but only use if overridden' for workspace config, so you have to [use something like a tri-state enum](https://devforum.nova.app/t/override-global-configuration-in-workspace/1824/3), and unfortunately enums, even though they support separate values. This PR adds a tri-state enum. An alternative would be to use two booleans, e.g. `workspace.formatOnSaveOverride && workspace.formatOnSave`.